### PR TITLE
Duplicate boards

### DIFF
--- a/client/src/pages/Footer.js
+++ b/client/src/pages/Footer.js
@@ -30,11 +30,11 @@ const Footer = () => {
               Terms
             </Link>
           </Grid>
-          <Grid item xs align="center">
+          {/* <Grid item xs align="center">
             <Link variant="body1" color="black" underline="hover" href="">
               Contact
             </Link>
-          </Grid>
+          </Grid> */}
         </Grid>
       </Box>
 

--- a/client/src/pages/board/Board.js
+++ b/client/src/pages/board/Board.js
@@ -117,12 +117,25 @@ const Board = ({ id }) => {
   };
 
   const updateBoard = async () => {
+
+    let title = JSON.parse(JSON.stringify(newTitle))
+    console.log(title)
+
+    if(boards.includes(title)) {
+      let i = 1
+      while(boards.includes(title + i)) {
+        i++
+      }
+      title = title + i
+      setNewTitle(title)
+    }
+
     setSaveButton(false);
     await fetch("http://localhost:8080/api/boards/update", {
       method: "PATCH",
       body: JSON.stringify({
         boardName: currBoard,
-        newBoardName: newTitle,
+        newBoardName: title,
       }),
       headers: {
         "Content-type": "application/json; charset=UTF-8",
@@ -134,12 +147,12 @@ const Board = ({ id }) => {
         boards.map((board, i) => {
           if (board == currBoard) {
             let temp = boards.slice();
-            temp[i] = newTitle;
+            temp[i] = title;
             setBoards(temp);
             console.log("hey " + boards + i + " " + temp);
           }
         });
-        setCurrBoard(newTitle);
+        setCurrBoard(title);
       })
       .catch((err) => console.log(err));
   };

--- a/client/src/pages/board/Workspace.js
+++ b/client/src/pages/board/Workspace.js
@@ -17,6 +17,15 @@ const Workspace = ({ checkCredentials, boards, setBoards, setCurrBoard }) => {
   const [createBoard, setCreateBoard] = useState(false);
 
   const handleNewBoard = async (title) => {
+
+    if(boards.includes(title)) {
+      let i = 1
+      while(boards.includes(title + i)) {
+        i++
+      }
+      title = title + i
+    }
+
     setBoards([...boards, title]);
     await fetch("http://localhost:8080/api/boards/save", {
       method: "POST",


### PR DESCRIPTION
Added some code in boards and workspaces pages to prevent duplicate boards from populating the database if the user inputs a board name that already exists in their workspace. This prevents duplicates from both creating and updating boards. Also lumped in removal of contact link in the footer, because I didnt feel like making a new branch to comment out 3 lines of code...